### PR TITLE
fix: フォームバリデーションとUI改善

### DIFF
--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -43,9 +43,17 @@ const DialogContent = React.forwardRef<
         scrollbarWidth: "thin",
         scrollbarColor: "rgba(0,0,0,0.2) transparent",
       }}
+      aria-describedby={props["aria-describedby"] || "dialog-description"}
       {...props}
     >
-      <div className="overflow-y-auto">{children}</div>
+      <div className="overflow-y-auto">
+        {!props["aria-describedby"] && (
+          <div id="dialog-description" className="sr-only">
+            ダイアログの内容
+          </div>
+        )}
+        {children}
+      </div>
       <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
         <X className="h-4 w-4" />
         <span className="sr-only">ダイアログを閉じる</span>


### PR DESCRIPTION
- サプリ名を必須入力に設定
- 内容量と一回の服用量を正の整数に制限し、初期値を1に設定
- タイミングベース選択時に少なくとも1つの時間帯を必須に
- カプセルという単位選択肢を削除（錠と同義のため）
- チェックボックスとラベルの上下揃えを修正
- スマホ表示時の内容量単位選択のフォーカススタイルをPC表示と統一