### PR TITLE
chore: finalize reactbits mcp setup and docs split

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,5 @@ dist/
 .gemini/
 output/
 .devchain/
+# local patch backups
+patches/*.patch

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,8 @@
 9. `.cursor/docs/cursor-submodule-management.md`
 10. `.cursor/docs/branch-strategy.md`
 11. `.cursor/docs/browser-research-ops.md`
-12. `README.md`
+12. `.cursor/docs/reactbits-mcp-ops.md`
+13. `README.md`
 
 補足:
 
@@ -46,7 +47,7 @@ UI/UX・機能・運用に関わる変更を行ったら、同ターンで必ず
   - ブレスト中で確定した項目はチェックリストへ移動
   - 実装済みが「未確定/ブレスト中」に残っていたら削除
   - 実装ログは必ず「新しいものを上、古いものを下」
-- 運用変更は対象ドキュメントへ更新（`branch-strategy.md` / `e2e-test-integration-checklist.md` / `devchain-cli-agent-collab-notes.md` / `browser-research-ops.md` / `agent-ops-commands.md`）
+- 運用変更は対象ドキュメントへ更新（`branch-strategy.md` / `e2e-test-integration-checklist.md` / `devchain-cli-agent-collab-notes.md` / `browser-research-ops.md` / `reactbits-mcp-ops.md` / `agent-ops-commands.md`）
 - リファクタ関連の変更時は `.cursor/docs/refactoring-checklist.md` も更新
 - E2E/テスト基盤変更時は `.cursor/docs/e2e-test-integration-checklist.md` も更新
 - コード変更後は `.cursor/docs/project-overview.yaml` の更新要否を確認し、必要なら反映する
@@ -61,8 +62,7 @@ UI/UX・機能・運用に関わる変更を行ったら、同ターンで必ず
 - 設定系は `src/lib/firebaseClient.ts` 一元管理方針を守る。
 - データ構造/権限モデル変更時は、`firestore.rules` とアプリ実装の整合を必ず確認する。
 - Firebaseの権限はサーバールールに加えて、クライアント側でも対象データ所有チェックを行う。
-- MCP併用時は役割を固定する（探索=`reactbits`、導入=`shadcn`）。`reactbits_dev` にリネームした場合も同じ役割で扱う。
-- MCP利用方針をユーザーが明示したターンでは、その方針を優先し、未使用側MCPの自動提案はしない。
+- React Bits MCP の探索/導入ルールは `.cursor/docs/reactbits-mcp-ops.md` を正本として参照する。
 - ブラウザ調査ツール（Web検索 / agent-browser / chrome-devtools-mcp）の運用順序と判定基準は `.cursor/docs/browser-research-ops.md` を正本として参照する。
 
 ## 5. 実装後レビュー参照

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,6 +61,8 @@ UI/UX・機能・運用に関わる変更を行ったら、同ターンで必ず
 - 設定系は `src/lib/firebaseClient.ts` 一元管理方針を守る。
 - データ構造/権限モデル変更時は、`firestore.rules` とアプリ実装の整合を必ず確認する。
 - Firebaseの権限はサーバールールに加えて、クライアント側でも対象データ所有チェックを行う。
+- MCP併用時は役割を固定する（探索=`reactbits`、導入=`shadcn`）。`reactbits_dev` にリネームした場合も同じ役割で扱う。
+- MCP利用方針をユーザーが明示したターンでは、その方針を優先し、未使用側MCPの自動提案はしない。
 - ブラウザ調査ツール（Web検索 / agent-browser / chrome-devtools-mcp）の運用順序と判定基準は `.cursor/docs/browser-research-ops.md` を正本として参照する。
 
 ## 5. 実装後レビュー参照

--- a/components.json
+++ b/components.json
@@ -17,5 +17,8 @@
     "lib": "@/lib",
     "hooks": "@/hooks"
   },
+  "registries": {
+    "@react-bits": "https://reactbits.dev/r/{name}.json"
+  },
   "iconLibrary": "lucide"
 }


### PR DESCRIPTION
## Summary
- add React Bits MCP setup in app config (`components.json` registry)
- update operation references in `AGENTS.md` to use dedicated docs
- keep local patch backup files out of git (`.gitignore`)
- update `.cursor` submodule pointer to include:
  - React Bits MCP setup + UI log records
  - separation of React Bits MCP ops guide from devchain notes

## Scope
- config + docs only
- no React Bits UI implementation code in this PR

## Related
- `.cursor` PR (merged): https://github.com/yugo969/supplement-app-cursor-config/pull/2

## Checks
- `npm run -s type-check`
- pre-commit checks passed on each commit (`SKIP_E2E=1` for docs/config-only commits)
